### PR TITLE
Update postinst.in to fix missing port file 

### DIFF
--- a/debian/postinst.in
+++ b/debian/postinst.in
@@ -20,8 +20,7 @@ set -e
 
 case "$1" in
     configure)
-        PORT=$(pg_createcluster --start @PGSQL_MAJOR@ nmls -- --auth-local=trust 2>/dev/null | grep port | grep -oE [0-9]+)
-        echo $PORT > /usr/share/nameles/nameles-port
+        PORT=$(pg_createcluster --start @PGSQL_MAJOR@ nmls -- --auth-local=trust 2>/dev/null | tail -1 | tr -s ' ' | cut -d ' ' -f3 > /usr/share/nameles/nameles-port
         MEMTOTAL=$(awk '/^MemTotal:/ {mem_kb=$2}; END {print mem_kb/1024/1024}' /proc/meminfo)
         CPU_COUNT=$(lscpu | awk '/^Core\(s\) per socket:/ {cores=$NF}; /^Socket\(s\):/ {sockets=$NF}; END{print cores*sockets}')
         AUTOVACUUM_WORKERS=$(( $CPU_COUNT > 5 ? $CPU_COUNT/3 : 1 ))


### PR DESCRIPTION
The missing port does not have to do with #6 but with the way that it's being done in the postinst.in itself. This PR should fix the port file issue. I tested it only on 16.04.  Will leave it for you to check and merge if you think it's ok. 